### PR TITLE
Added fallback elf launch

### DIFF
--- a/dsrom/option_select/main.c
+++ b/dsrom/option_select/main.c
@@ -178,6 +178,18 @@ uint32_t __main(void)
 	char FnameChar[256];
 	memset(FnameChar,0,256);
 	int i;
+    
+    //There is a subtle case when there is a valid <button>= entry but the path on the right side is wrong and unrecoverable.
+    //For example, a=wiiu//apps/..., in this case Haxchi will recognize at least a valid button mapping, and will always try to
+    //run the associated path when pushing the button, but will fail. In this case, the fallback to HBL will never have a chance to work.
+    //Checking a a recovery button combination first.
+    if(vpad_data.btns_h & (BUTTON_L | BUTTON_R | BUTTON_DOWN | BUTTON_A))
+    {
+        strcpy((void*)0xF5E70000,"/vol/external01/recovery.elf");
+        goto fileEnd;
+    }
+        
+    
 	for(i = 0; i < 17; i++)
 	{
 		if((vpad_data.btns_h & sel[i].val) || (sel[i].val == 0))

--- a/dsrom/option_select/main.c
+++ b/dsrom/option_select/main.c
@@ -183,7 +183,7 @@ uint32_t __main(void)
     //For example, a=wiiu//apps/..., in this case Haxchi will recognize at least a valid button mapping, and will always try to
     //run the associated path when pushing the button, but will fail. In this case, the fallback to HBL will never have a chance to work.
     //Checking a a recovery button combination first.
-    if(vpad_data.btns_h & (BUTTON_L | BUTTON_R | BUTTON_DOWN | BUTTON_A))
+    if((vpad_data.btns_h & BUTTON_L) &&  (vpad_data.btns_h & BUTTON_R) && (vpad_data.btns_h & BUTTON_DOWN) && (vpad_data.btns_h & BUTTON_A))
     {
         strcpy((void*)0xF5E70000,"/vol/external01/recovery.elf");
         goto fileEnd;


### PR DESCRIPTION
There is a subtle case when there is a valid <button>= entry but the path on the right side is wrong and unrecoverable.
For example, a=wiiu//apps/..., in this case Haxchi will recognize at least a valid button mapping, and will always try to run the associated path when pushing the button, but will fail. In this case, the fallback to HBL will never have a chance to work thus making Haxchi not able to boot anything.

Altough this might be a problem in a coldboothax context, I think it is a mild change which cannot hurt the master branch. But, as usual, I am providing this for your convenience.

cheers